### PR TITLE
Make Seconds Optional

### DIFF
--- a/UTCMenuClock/UTCMenuClockAppDelegate.m
+++ b/UTCMenuClock/UTCMenuClockAppDelegate.m
@@ -197,9 +197,8 @@ NSMenuItem   *dateMenuItem;
     [mainMenu addItem:sep3Item];
 
     // showDateItem
-    NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
-    BOOL showDate = [standardUserDefaults boolForKey:@"ShowDate"];
-    BOOL showSeconds = [standardUserDefaults boolForKey:@"ShowSeconds"];
+    BOOL showDate = [self fetchBooleanPreference:@"ShowDate"];
+    BOOL showSeconds = [self fetchBooleanPreference:@"ShowSeconds"];
 
     if (showDate) {
         [showDateItem setState:NSOnState];


### PR DESCRIPTION
Hey Netik,

First of all, this is my first time seeing objective-c, so bear with me!

I've changed a couple things around to allow seconds to be optional in the clock, since I find them to be a little bit distracting. I'd love to submit these changes back if possible.

Additionally, I refactored the preference writing to allow getting and setting of preferences. I'm not really sure what the common objective-c pattern is here, so I made one up. Let me know if there's a better way to do this, again, all brand new to me!

There are a lot of whitespace cleanups in this file too, so it looks like it changes more code than it really does.

Look forward to hearing from you,
Alex
