### PR TITLE
Adjust NSTimer to reduce CPU usage

### DIFF
--- a/UTCMenuClock/UTCMenuClockAppDelegate.m
+++ b/UTCMenuClock/UTCMenuClockAppDelegate.m
@@ -526,10 +526,14 @@ NSTimer *timer;
     if ([self fetchBooleanPreference:showSecondsPreferenceKey]) {
         // Update every 1 second with 50ms of tolerance to allow for CPU sleep
         // (Chosen arbitrarily: 100ms of tolerance makes the updates visibly irregular, 50ms looks fine)
+        
+        // Start at the next whole second
+        [startUnits setSecond:[startUnits second] + 1.0];
+
         interval = 1.0;
         tolerance = 0.05;
     } else {
-        // If we're not showing seconds, set the timer to fire the next whole minute then every 60 seconds
+        // If we're not showing seconds, set the timer to fire at the next whole minute then every 60 seconds
         [startUnits setSecond:0];
         [startUnits setMinute:[startUnits minute] + 1.0];
         

--- a/UTCMenuClock/UTCMenuClockAppDelegate.m
+++ b/UTCMenuClock/UTCMenuClockAppDelegate.m
@@ -509,9 +509,15 @@ NSTimer *timer;
     // Update the date immediately
     [self doDateUpdate];
 
-    // Get the current date (without ms)
-    NSDate *startDateTime = [NSDate date];
-    NSDateComponents *startUnits = [[NSCalendar currentCalendar] components: (NSDayCalendarUnit | NSYearCalendarUnit | NSMonthCalendarUnit | NSCalendarUnitHour | NSSecondCalendarUnit | NSMinuteCalendarUnit) fromDate: startDateTime];
+    // Get the current date components (without ms)
+    NSDateComponents *startUnits = [[NSCalendar currentCalendar] components:
+                                    (NSYearCalendarUnit |
+                                     NSMonthCalendarUnit |
+                                     NSDayCalendarUnit |
+                                     NSCalendarUnitHour |
+                                     NSMinuteCalendarUnit |
+                                     NSSecondCalendarUnit)
+                                                                   fromDate: [NSDate date]];
 
     NSTimeInterval interval;
     NSTimeInterval tolerance;
@@ -522,7 +528,6 @@ NSTimer *timer;
         // (Chosen arbitrarily: 100ms of tolerance makes the updates visibly irregular, 50ms looks fine)
         interval = 1.0;
         tolerance = 0.05;
-
     } else {
         // If we're not showing seconds, set the timer to fire the next whole minute then every 60 seconds
         [startUnits setSecond:0];
@@ -536,7 +541,7 @@ NSTimer *timer;
     // Set up wake notifications to reset the timer after sleep
     [self fileNotifications];
 
-    startDateTime = [[NSCalendar currentCalendar] dateFromComponents:startUnits];
+    NSDate *startDateTime = [[NSCalendar currentCalendar] dateFromComponents:startUnits];
     timer = [[NSTimer alloc] initWithFireDate:startDateTime interval:interval target:self selector:@selector(fireTimer:) userInfo:nil repeats:YES];
     timer.tolerance = tolerance;
     


### PR DESCRIPTION
Hello! Thank you for developing UTCMenuClock, it's a very useful tool! 😄

We've noticed that when "show seconds" is disabled, the time still redraws once per second, potentially impacting battery life. This includes string drawing, XPC calls to cfprefsd, and icu date formatting.

To fix this, I've configured the NSTimer to only fire once per minute on the minute, reducing CPU usage from ~0.5% to 0%.

I also added a little bit of tolerance (~50ms) when seconds are enabled, which should allow the CPU to sleep between updates.

## Before
<img width="1240" alt="CleanShot 2023-01-18 at 11 53 08@2x" src="https://user-images.githubusercontent.com/52758633/213280881-c64fbc17-9ea8-44cd-863b-b014203f3e29.png">

## After
<img width="1241" alt="CleanShot 2023-01-18 at 11 53 36@2x" src="https://user-images.githubusercontent.com/52758633/213280984-01fe591c-a68d-46bc-a086-d7abe4bf4ca4.png">
