### PR TITLE
Use the system font with monospace digits

### DIFF
--- a/UTCMenuClock.xcodeproj/project.pbxproj
+++ b/UTCMenuClock.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -218,8 +218,9 @@
 		A8B1187D1471AE3A008A993B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastTestingUpgradeCheck = 0730;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					A8B118851471AE3A008A993B = {
@@ -378,6 +379,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -429,6 +431,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -459,6 +462,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "UTCMenuClock/UTCMenuClock-Prefix.pch";
 				INFOPLIST_FILE = "UTCMenuClock/UTCMenuClock-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.retina.UTCMenuClock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -479,6 +483,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "UTCMenuClock/UTCMenuClock-Prefix.pch";
 				INFOPLIST_FILE = "UTCMenuClock/UTCMenuClock-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.retina.UTCMenuClock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -496,6 +501,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "UTCMenuClock/UTCMenuClock-Prefix.pch";
 				INFOPLIST_FILE = "UTCMenuClockTests/UTCMenuClockTests-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.retina.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
@@ -514,6 +520,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "UTCMenuClock/UTCMenuClock-Prefix.pch";
 				INFOPLIST_FILE = "UTCMenuClockTests/UTCMenuClockTests-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.retina.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";

--- a/UTCMenuClock.xcodeproj/xcshareddata/xcschemes/UTCMenuClock - Release.xcscheme
+++ b/UTCMenuClock.xcodeproj/xcshareddata/xcschemes/UTCMenuClock - Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UTCMenuClock.xcodeproj/xcshareddata/xcschemes/UTCMenuClock.xcscheme
+++ b/UTCMenuClock.xcodeproj/xcshareddata/xcschemes/UTCMenuClock.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UTCMenuClock/UTCMenuClock-Info.plist
+++ b/UTCMenuClock/UTCMenuClock-Info.plist
@@ -23,7 +23,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9</string>
+	<string>11.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/UTCMenuClock/UTCMenuClockAppDelegate.m
+++ b/UTCMenuClock/UTCMenuClockAppDelegate.m
@@ -63,11 +63,11 @@ NSMenuItem *showTimeZoneItem;
     NSInteger state = [sender state];
     LaunchAtLoginController *launchController = [[LaunchAtLoginController alloc] init];
     
-    if (state == NSOffState) {
-        [sender setState:NSOnState];
+    if (state == NSControlStateValueOff) {
+        [sender setState:NSControlStateValueOn];
         [launchController setLaunchAtLogin:YES];
     } else {
-        [sender setState:NSOffState];
+        [sender setState:NSControlStateValueOff];
         [launchController setLaunchAtLogin:NO];
     }
     
@@ -94,11 +94,11 @@ NSMenuItem *showTimeZoneItem;
     NSString *preference = [sender representedObject];
     NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
     
-    if (state == NSOffState) {
-        [sender setState:NSOnState];
+    if (state == NSControlStateValueOff) {
+        [sender setState:NSControlStateValueOn];
         [standardUserDefaults setBool:TRUE forKey:preference];
     } else {
-        [sender setState:NSOffState];
+        [sender setState:NSControlStateValueOff];
         [standardUserDefaults setBool:FALSE forKey:preference];
     }
     
@@ -113,7 +113,7 @@ NSMenuItem *showTimeZoneItem;
     
     [self togglePreference:sender];
     
-    if (state == NSOffState) {
+    if (state == NSControlStateValueOff) {
         // disable all of the menu items which are not related to ISO state
         [show24Item setEnabled:FALSE];
         [showDateItem setEnabled:FALSE];
@@ -440,14 +440,14 @@ NSMenuItem *showTimeZoneItem;
     BOOL showISOInstead = [self fetchBooleanPreference:showISO8601PreferenceKey];
 
     // set the menu states based on the preferences
-    [show24Item setState:show24HrTime ? NSOnState : NSOffState];
-    [showDateItem setState:showDate ? NSOnState : NSOffState];
-    [showSecondsItem setState:showSeconds ? NSOnState : NSOffState];
-    [showJulianItem setState:showJulian ? NSOnState : NSOffState];
-    [showTimeZoneItem setState:showTimeZone ? NSOnState : NSOffState];
+    [show24Item setState:show24HrTime ? NSControlStateValueOn : NSControlStateValueOff];
+    [showDateItem setState:showDate ? NSControlStateValueOn : NSControlStateValueOff];
+    [showSecondsItem setState:showSeconds ? NSControlStateValueOn : NSControlStateValueOff];
+    [showJulianItem setState:showJulian ? NSControlStateValueOn : NSControlStateValueOff];
+    [showTimeZoneItem setState:showTimeZone ? NSControlStateValueOn : NSControlStateValueOff];
     
     if (showISOInstead) {
-        [showISO8601Item setState:NSOnState];
+        [showISO8601Item setState:NSControlStateValueOn];
         
         // disable all of the menu items which are not related to ISO state
         [show24Item setEnabled:FALSE];
@@ -457,7 +457,7 @@ NSMenuItem *showTimeZoneItem;
         [showTimeZoneItem setEnabled:FALSE];
     
     } else {
-        [showISO8601Item setState:NSOffState];
+        [showISO8601Item setState:NSControlStateValueOff];
 
         // enable all of the menu items which are not related to ISO state
         [show24Item setEnabled:TRUE];
@@ -472,7 +472,7 @@ NSMenuItem *showTimeZoneItem;
     BOOL launch = [launchController launchAtLogin];
     [launchController release];
     
-    [launchItem setState:launch ? NSOnState : NSOffState];
+    [launchItem setState:launch ? NSControlStateValueOn : NSControlStateValueOff];
     
     [mainMenu addItem:launchItem];
     [mainMenu addItem:show24Item];

--- a/UTCMenuClock/UTCMenuClockAppDelegate.m
+++ b/UTCMenuClock/UTCMenuClockAppDelegate.m
@@ -258,14 +258,12 @@ NSMenuItem *showTimeZoneItem;
  */
 - (void) doDateUpdate {
     NSString *dateString = [self makeDateString];
-    [ourStatus setTitle:dateString];
-    
+    ourStatus.button.title = dateString;
 }
 
 // Unused for now... need to finish.
 - (IBAction)showFontMenu:(id)sender {
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
-    [fontManager setDelegate:self];
     
     NSFontPanel *fontPanel = [fontManager fontPanel:YES];
     [fontPanel makeKeyAndOrderFront:sender];
@@ -318,14 +316,6 @@ NSMenuItem *showTimeZoneItem;
     [theItem retain];
     // retain a reference to the item so we don't have to find it again
     ourStatus = theItem;
-    
-    //Set Image
-    //[theItem setImage:(NSImage *)menuicon];
-    [theItem setTitle:@""];
-    
-    //Make it turn blue when you click on it
-    [theItem setHighlightMode:YES];
-    [theItem setEnabled: YES];
     
     // build the menu
     NSMenuItem *mainItem = [[NSMenuItem alloc] init];

--- a/UTCMenuClock/UTCMenuClockAppDelegate.m
+++ b/UTCMenuClock/UTCMenuClockAppDelegate.m
@@ -314,6 +314,9 @@ NSMenuItem *showTimeZoneItem;
     NSStatusItem *theItem;
     theItem = [bar statusItemWithLength:NSVariableStatusItemLength];
     [theItem retain];
+    // while some day we may want more customizable font selection, for now
+    // set the system font to use fixed-width digits
+    theItem.button.font = [NSFont monospacedDigitSystemFontOfSize:NSFont.systemFontSize weight:NSFontWeightRegular];
     // retain a reference to the item so we don't have to find it again
     ourStatus = theItem;
     


### PR DESCRIPTION
This makes some progress towards #16 without fully implementing an arbitrarily selectable font.

Xcode was also printing a bunch of warnings which I fixed, bumping the minimum supported version -- this is _required_ for this method of setting the font, though if we wanted to keep the deprecated stuff for better compatibility we could use an attributed string instead.