### PR TITLE
Fix duplicate NSWorkspaceDidWakeNotification observations

### DIFF
--- a/UTCMenuClock/UTCMenuClockAppDelegate.m
+++ b/UTCMenuClock/UTCMenuClockAppDelegate.m
@@ -471,8 +471,16 @@ static NSString *const GITHUB_URL = @"http://github.com/netik/UTCMenuClock";
     [_mainMenu addItem:cp3Item];
 
     [theItem setMenu:_mainMenu];
-    
+    [self setupWakeNotifications];
     [self scheduleTimer];
+}
+
+- (void)setupWakeNotifications
+{
+    // https://developer.apple.com/library/archive/qa/qa1340/_index.html
+    [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver: self
+            selector: @selector(receiveWakeNote:)
+            name: NSWorkspaceDidWakeNotification object: nil];
 }
 
 - (void)scheduleTimer {
@@ -516,9 +524,6 @@ static NSString *const GITHUB_URL = @"http://github.com/netik/UTCMenuClock";
         tolerance = 0.5;
     }
     
-    // Set up wake notifications to reset the timer after sleep
-    [self fileNotifications];
-
     NSDate *startDateTime = [[NSCalendar currentCalendar] dateFromComponents:startUnits];
     _timer = [[NSTimer alloc] initWithFireDate:startDateTime interval:interval target:self selector:@selector(fireTimer:) userInfo:nil repeats:YES];
     _timer.tolerance = tolerance;
@@ -531,14 +536,6 @@ static NSString *const GITHUB_URL = @"http://github.com/netik/UTCMenuClock";
 {
     // When the machine wakes from sleep, reset our timer to make sure we're still running on the second/minute
     [self scheduleTimer];
-}
- 
-- (void)fileNotifications
-{
-    // https://developer.apple.com/library/archive/qa/qa1340/_index.html
-    [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver: self
-            selector: @selector(receiveWakeNote:)
-            name: NSWorkspaceDidWakeNotification object: nil];
 }
 
 - (void)dealloc


### PR DESCRIPTION
I incorrectly added an observer to `NSWorkspaceDidWakeNotification` during the `scheduleTimer` function. When showing seconds, this means that UTCMenuClock would re-register for the notification *every second*, *and* it would re-register observation that many times on each wake. This caused https://github.com/netik/UTCMenuClock/issues/20.

Moving the observation to `awakeFromNib` should fix it. I also renamed the function to make it clearer that this should be only called once. Sorry for breaking it!